### PR TITLE
Fix some printf-related compilation warnings

### DIFF
--- a/jsdump.c
+++ b/jsdump.c
@@ -807,26 +807,26 @@ void js_dumpvalue(js_State *J, js_Value v)
 			break;
 		}
 		switch (v.u.object->type) {
-		case JS_COBJECT: printf("[Object %p]", v.u.object); break;
-		case JS_CARRAY: printf("[Array %p]", v.u.object); break;
+		case JS_COBJECT: printf("[Object %p]", (void*)v.u.object); break;
+		case JS_CARRAY: printf("[Array %p]", (void*)v.u.object); break;
 		case JS_CFUNCTION:
 			printf("[Function %p, %s, %s:%d]",
-				v.u.object,
+				(void*)v.u.object,
 				v.u.object->u.f.function->name,
 				v.u.object->u.f.function->filename,
 				v.u.object->u.f.function->line);
 			break;
 		case JS_CSCRIPT: printf("[Script %s]", v.u.object->u.f.function->filename); break;
-		case JS_CCFUNCTION: printf("[CFunction %p]", v.u.object->u.c.function); break;
+		case JS_CCFUNCTION: printf("[CFunction %p]", (void*)v.u.object->u.c.function); break;
 		case JS_CBOOLEAN: printf("[Boolean %d]", v.u.object->u.boolean); break;
 		case JS_CNUMBER: printf("[Number %g]", v.u.object->u.number); break;
 		case JS_CSTRING: printf("[String'%s']", v.u.object->u.s.string); break;
 		case JS_CERROR: printf("[Error %s]", v.u.object->u.s.string); break;
-		case JS_CITERATOR: printf("[Iterator %p]", v.u.object); break;
+		case JS_CITERATOR: printf("[Iterator %p]", (void*)v.u.object); break;
 		case JS_CUSERDATA:
 			printf("[Userdata %s %p]", v.u.object->u.user.tag, v.u.object->u.user.data);
 			break;
-		default: printf("[Object %p]", v.u.object); break;
+		default: printf("[Object %p]", (void*)v.u.object); break;
 		}
 		break;
 	}


### PR DESCRIPTION
Cast some pointers to (void*) in order to make gcc stop complaining
about wrong pointer format user with format %p in printf.
