### PR TITLE
Use <stdint.h> for VS2012

### DIFF
--- a/jsdtoa.c
+++ b/jsdtoa.c
@@ -2,7 +2,8 @@
 
 #include "jsi.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1700) /* VS2012 has stdint.h */
+typedef unsigned int uint32_t;
 typedef unsigned __int64 uint64_t;
 #else
 #include <stdint.h>


### PR DESCRIPTION
As <stdint.h> is available since VS2012, we can start using it depending on the _MSC_VER value.

This commit also added the required definition of uint32_t in case that
we cannot use <stdint.h> on older MSVC versions.

Tested compiling with VS2015.