### PR TITLE
remove js_settop from mujs.h because it has no implemtation.

### DIFF
--- a/mujs.h
+++ b/mujs.h
@@ -193,7 +193,6 @@ short js_toint16(js_State *J, int idx);
 unsigned short js_touint16(js_State *J, int idx);
 
 int js_gettop(js_State *J);
-void js_settop(js_State *J, int idx);
 void js_pop(js_State *J, int n);
 void js_rot(js_State *J, int n);
 void js_copy(js_State *J, int idx);


### PR DESCRIPTION
I found js_settop has no implemtation, use js_pop instead of js_settop，so remove js_settop from mujs.h?