### PR TITLE
fix split doesn't convert context to string if no argument is passed

### DIFF
--- a/jsstring.c
+++ b/jsstring.c
@@ -665,7 +665,7 @@ static void Sp_split(js_State *J)
 {
 	if (js_isundefined(J, 1)) {
 		js_newarray(J);
-		js_copy(J, 0);
+		js_pushstring(J, js_tostring(J, 0));
 		js_setindex(J, -2, 0);
 	} else if (js_isregexp(J, 1)) {
 		Sp_split_regexp(J);


### PR DESCRIPTION
As a result can't pass a simple test like this:

```js
var str = new String("abc");
var splits = str.split();
if (splits[0] !== "abc") {
	throw new Error('splits[0] !== "abc"');
}
```
Because resulted array contains reference to a context object as first argument.
