### PR TITLE
Fix crash when length is negative

### DIFF
--- a/jsarray.c
+++ b/jsarray.c
@@ -103,7 +103,7 @@ static void Ap_join(js_State *J)
 		seplen = 1;
 	}
 
-	if (len == 0) {
+	if (len <= 0) {
 		js_pushliteral(J, "");
 		return;
 	}


### PR DESCRIPTION
When the `len` is negative, mujs will crash due to a null pointer de-reference.

```
char * volatile out = NULL;
...
js_pushstring(..., out);
...
strlen(out);
```