### PR TITLE
Fix js_strtol

### DIFF
--- a/jsvalue.c
+++ b/jsvalue.c
@@ -31,7 +31,7 @@ double js_strtol(const char *s, char **p, int base)
 	double x;
 	int c;
 	if (base == 10)
-		for (x = 0, c = *s++; c - '0' < 10; c = *s++)
+		for (x = 0, c = *s++; (0 <= c - '0') && (c - '0' < 10); c = *s++)
 			x = x * 10 + (c - '0');
 	else
 		for (x = 0, c = *s++; table[c] < base; c = *s++)


### PR DESCRIPTION
The current logic does not account for values < '0', which at a minimum are guaranteed to exist for the null byte at the end of the string. This results in incorrect answers, and also potentially crashes. For instance, `[2] * [3]` produces `NaN`, but should produce `6`. This patch fixes that. 

```
root@7889a0b36f93:/mujs# echo '[]*[]' | /mujs/build/sanitize/mujs
=================================================================
==133==ERROR: AddressSanitizer: global-buffer-overflow on address 0x558d106672e1 at pc 0x558d106572cd bp 0x7fffee8f8f40 sp 0x7fffee8f8f30
READ of size 1 at 0x558d106672e1 thread T0
    #0 0x558d106572cc in js_strtol /mujs/jsvalue.c:34
    #1 0x558d10658493 in js_stringtofloat /mujs/jsvalue.c:212
    #2 0x558d1065895e in jsV_stringtonumber /mujs/jsvalue.c:236
    #3 0x558d10658c8a in jsV_tonumber /mujs/jsvalue.c:252
    #4 0x558d10658cfe in jsV_tonumber /mujs/jsvalue.c:256
    #5 0x558d106448aa in js_tonumber /mujs/jsrun.c:278
    #6 0x558d1065013a in jsR_run /mujs/jsrun.c:1650
    #7 0x558d1064ad33 in jsR_callscript /mujs/jsrun.c:1069
    #8 0x558d1064b80a in js_call /mujs/jsrun.c:1124
    #9 0x558d10651f4d in js_dostring /mujs/jsstate.c:204
    #10 0x558d1066711a in main /mujs/main.c:373
    #11 0x7f18586b7bf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)
    #12 0x558d10602ca9 in _start (/mujs/build/sanitize/mujs+0x16ca9)

0x558d106672e1 is located 63 bytes to the left of global variable '*.LC6' defined in 'one.c' (0x558d10667320) of size 27
  '*.LC6' is ascii string 'array is too large to sort'
0x558d106672e1 is located 0 bytes to the right of global variable '*.LC4' defined in 'one.c' (0x558d106672e0) of size 1
  '*.LC4' is ascii string ''
SUMMARY: AddressSanitizer: global-buffer-overflow /mujs/jsvalue.c:34 in js_strtol
Shadow bytes around the buggy address:
  0x0ab2220c4e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2220c4e10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2220c4e20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2220c4e30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab2220c4e40: 00 00 00 00 00 00 00 00 07 f9 f9 f9 f9 f9 f9 f9
=>0x0ab2220c4e50: 00 00 00 00 02 f9 f9 f9 f9 f9 f9 f9[01]f9 f9 f9
  0x0ab2220c4e60: f9 f9 f9 f9 00 00 00 03 f9 f9 f9 f9 00 00 00 03
  0x0ab2220c4e70: f9 f9 f9 f9 00 00 01 f9 f9 f9 f9 f9 00 00 00 01
  0x0ab2220c4e80: f9 f9 f9 f9 00 00 07 f9 f9 f9 f9 f9 00 00 05 f9
  0x0ab2220c4e90: f9 f9 f9 f9 00 00 04 f9 f9 f9 f9 f9 00 00 05 f9
  0x0ab2220c4ea0: f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9 00 00 06 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==133==ABORTING
```