### PR TITLE
Makefile: fix parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ $(OUT)/mujs-pp: $(OUT)/libmujs.o $(OUT)/pp.o
 
 .PHONY: $(OUT)/mujs.pc
 $(OUT)/mujs.pc:
+	@ mkdir -p $(dir $@)
 	@ echo Creating $@
 	@ echo > $@ Name: mujs
 	@ echo >> $@ Description: MuJS embeddable Javascript interpreter


### PR DESCRIPTION
The parent directory wasn't created when generating the .pc file, causing it to fail in highly parallel builds.