### PR TITLE
pkg-config: use prefix/libdir/includedir for pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,16 @@ build/release/mujs-pp: pp.c build/release/libmujs.o
 
 build/release/mujs.pc:
 	@mkdir -p $(@D)
-	echo > $@ Name: mujs
+	echo > $@ prefix=$(prefix)
+	echo >> $@ exec_prefix=\$${prefix}
+	echo >> $@ libdir=\$${prefix}/lib
+	echo >> $@ includedir=\$${prefix}/include
+	echo >> $@
+	echo >> $@ Name: mujs
 	echo >> $@ Description: MuJS embeddable Javascript interpreter
 	echo >> $@ Version: $(VERSION)
-	echo >> $@ Cflags: -I$(incdir)
-	echo >> $@ Libs: -L$(libdir) -lmujs
+	echo >> $@ Cflags: -I\$${includedir}
+	echo >> $@ Libs: -L\$${libdir} -lmujs
 	echo >> $@ Libs.private: -lm
 
 install-common: build/release/mujs build/release/mujs-pp build/release/mujs.pc


### PR DESCRIPTION
Allows for pkg-config to reinterpret paths easier, for example on Windows.

An example where this is useful is with mpv, as meson will pull the ldflags and cflags from the pkg-config file and has `-L/prefix/lib -lmujs` in the linking command, but with this change, `pkgconf` can reinterpret the prefix and change it appropriately to something like `-LD:/prefix/lib -lmujs`